### PR TITLE
Fix proof payload naming for vote endpoint

### DIFF
--- a/app/api/vote/route.ts
+++ b/app/api/vote/route.ts
@@ -9,7 +9,7 @@ export async function POST(request: Request) {
   const { pollId, optionIdx, proof } = body;
 
   // 1. Validate body
-  if (!pollId || typeof optionIdx !== 'number' || !proof) {
+  if (!pollId || typeof optionIdx !== 'number' || !proof || typeof proof !== 'object') {
     return NextResponse.json({ error: 'Missing required fields.' }, { status: 400 });
   }
 
@@ -36,7 +36,8 @@ export async function POST(request: Request) {
 
   try {
     // 2. Call World ID Verify v2
-    const actionId = process.env.NEXT_PUBLIC_WLD_ACTION_ID_VOTE;
+    const actionId =
+      process.env.NEXT_PUBLIC_WORLDCON_ACTION_ID ?? process.env.NEXT_PUBLIC_WLD_ACTION_ID_VOTE;
     if (!actionId) throw new Error("Action ID is not configured.");
 
     console.log("Server: Verifying proof...");

--- a/components/VoteComponent.tsx
+++ b/components/VoteComponent.tsx
@@ -82,7 +82,7 @@ export default function VoteComponent({ poll }: VoteComponentProps) {
   };
 
   // action and signal are plain strings now
-  const handleVote = async (payload: ISuccessResult, action: string, signal: string) => {
+  const handleVote = async (proof: ISuccessResult, action: string, signal: string) => {
     if (selectedOption === null) return;
 
     try {
@@ -92,7 +92,7 @@ export default function VoteComponent({ poll }: VoteComponentProps) {
         body: JSON.stringify({
           pollId: poll.id,
           optionIdx: selectedOption,
-          payload,
+          proof,
           action,
           signal,
         }),


### PR DESCRIPTION
## Summary
- send the World ID verification object from the client as `proof`
- tighten API request validation and reuse the updated `proof` payload when verifying votes
- fall back to the WORLDCON action id on the server to stay aligned with the client

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1b8ec149083209fff13312a6d1dc3