### PR TITLE
Hash vote signal before verification

### DIFF
--- a/lib/worldid.ts
+++ b/lib/worldid.ts
@@ -3,7 +3,7 @@ interface VerifyReply {
   nullifier_hash: string;
 }
 
-export async function verifyProof(proof: any, actionId: string): Promise<VerifyReply> {
+export async function verifyProof(proof: any, actionId: string, hashedSignal?: string): Promise<VerifyReply> {
   const WLD_APP_ID = process.env.NEXT_PUBLIC_WLD_APP_ID;
 
   if (!WLD_APP_ID) {
@@ -22,6 +22,7 @@ export async function verifyProof(proof: any, actionId: string): Promise<VerifyR
     proof: proof.proof,
     verification_level: proof.verification_level,
     action: actionId,
+    signal: hashedSignal,
   };
 
   console.log("Sending to World ID:", { 


### PR DESCRIPTION
## Summary
- allow the vote API route to consume action and signal overrides, falling back to env defaults
- hash the vote signal before verification and pass it into World ID's verify API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b8ed48e08320b42c6bf82d0cf45b